### PR TITLE
Recognize more than the default config file

### DIFF
--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -1,5 +1,5 @@
 vim.filetype.add({
-  pattern = { ["~/.config/hypr/.*%.conf"] = "hypr" },
+  pattern = { [".*/hypr/.*%.conf"] = "hypr" },
 })
 
 vim.api.nvim_create_autocmd("FileType", {


### PR DESCRIPTION
I basically changed the lua-pattern to recognize all `.conf` files that live under a `hypr` folder to support more than just the `.config` directory.

This is useful in cases where your config isn't located in `.config`, which is usually the case for Nix users.

For example, my hyprland config is located at `~/.nix/devices/wim/config/hypr/main.conf`, which is recognized with this pattern.